### PR TITLE
add render function for usage not from command line + wrong fix for #16

### DIFF
--- a/src/nanim/core.nim
+++ b/src/nanim/core.nim
@@ -94,6 +94,22 @@ type
     done*: bool
     debug*: bool
 
+  RenderOptions* = object
+    debug*: bool
+    createVideo*: bool
+    createGif*: bool
+    createScreenshot*: bool
+
+    width*: int
+    height*: int
+
+    ratioHorizontal*: float
+    ratioVertical*: float
+
+    goalFPS*: float
+
+    folderPath*: string
+    fileName*: string
 
 const
   pointsPerCurve* = 3

--- a/src/nanim/rendering.nim
+++ b/src/nanim/rendering.nim
@@ -255,7 +255,7 @@ proc renderWithPipe(scene: Scene, filePath: string, createGif = false) =
     width: cint
     height: cint
 
-  scene.window.getWindowSize(width.addr, height.addr)
+  scene.window.getFramebufferSize(width.addr, height.addr)
 
   let
     rgbaSize = sizeof(cint)


### PR DESCRIPTION
the first commit:
- refactors render functions
- add type RenderOptions
- add a render function that can create a video without the need to pass command line options

the above was useful for me to create a nanim animation for today's advent of code: https://pietroppeter.github.io/adventofnim/2021/day07.html

as mentioned in #16 the fix in the second commit, although it seems wrong, improved a bit my situation and allowed me to complete the task. Once a better fix (or an explanation fo behavior) is available, we could merge all this. For the moment this is a draft.

Have a good day and thanks again for nanim!